### PR TITLE
Free champions carousel now only shows default skin rather than rando…

### DIFF
--- a/scenes/FreeChampions/FreeChampions.js
+++ b/scenes/FreeChampions/FreeChampions.js
@@ -27,8 +27,7 @@ class FreeChampions extends Component {
 		this.freeChampions = (freeChampions) ?
 			_.map(freeChampions, (champion) => {
 				const { skins } = champion;
-				var randomSkin = Math.floor(Math.random() * skins.length);
-				var skinUri =  skins[randomSkin].media.loading_url;
+				var skinUri =  skins[0].media.loading_url;
 
 				return {...champion, skinUri };
 			}) : null;


### PR DESCRIPTION
## Goal:
Free champions carousel now only shows default skin rather than random skins
## Add a screenshot/gif of changes
![](https://media.giphy.com/media/l4Ep6WBGTj441QaTm/giphy.gif)
## Where did you make changes (optional)
freechampions.js
